### PR TITLE
Fix navigation URL

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,9 +3,9 @@ main:
   - title: "TLX"
     url: https://training.ia-toki.org/
   - title: "TOKI"
-    url: https://www.toki.or.id/
+    url: http://www.toki.or.id/
   - title: "IA-TOKI"
-    url: https://www.ia-toki.org/
+    url: https://blog.ia-toki.org/
 
 
 


### PR DESCRIPTION
- toki.or.id don't use https
- ia-toki.org actually redirected to blog subdomain 
